### PR TITLE
Dev/all the constexpr

### DIFF
--- a/flexcore/core/connectables.hpp
+++ b/flexcore/core/connectables.hpp
@@ -24,19 +24,19 @@ namespace fc
 struct increment
 {
 	template<class T>
-	auto operator()(T in) const { return ++in; }
+	constexpr auto operator()(T in) const { return ++in; }
 };
 /// Decrements input using prefix operator --.
 struct decrement
 {
 	template<class T>
-	auto operator()(T in) const { return --in; }
+	constexpr auto operator()(T in) const { return --in; }
 };
 /// Returns input unchanged.
 struct identity
 {
 	template<class T>
-	T operator()(T in) const { return in; }
+	constexpr T operator()(T in) const { return in; }
 };
 /// Adds a constant addend to inputs.
 template<class T>
@@ -70,21 +70,21 @@ auto divide(const T divisor)
 struct absolute
 {
 	template<class T>
-	auto operator()(const T& in) const { return std::abs(in); }
+	constexpr auto operator()(const T& in) const { return std::abs(in); }
 };
 
 /// Negates input using unary -.
 struct negate
 {
 	template<class T>
-	auto operator()(const T& in) const { return -in; }
+	constexpr auto operator()(const T& in) const { return -in; }
 };
 
 /// Returns logical not (operator !) of input.
 struct logical_not
 {
 	template<class T>
-	auto operator()(const T& in) const { return !in; }
+	constexpr auto operator()(const T& in) const { return !in; }
 };
 
 /**

--- a/flexcore/core/connection.hpp
+++ b/flexcore/core/connection.hpp
@@ -15,18 +15,17 @@ namespace detail
 enum void_flag
 {
 	payload_void,
-	payload_not_void,
-	invalid,
+	payload_not_void
 };
 
 template<class source,class sink, class... P>
-constexpr auto void_check(int) ->  decltype(std::declval<sink>()(), std::declval<source>()(std::declval<P>()...), void_flag())
+constexpr auto void_check() ->  decltype(std::declval<sink>()(), std::declval<source>()(std::declval<P>()...), void_flag())
 {
 	return payload_void;
 }
 
 template<class source,class sink, class... P>
-constexpr auto void_check(int) ->  decltype(std::declval<sink>()(std::declval<source>()(std::declval<P>()...)), void_flag())
+constexpr auto void_check() ->  decltype(std::declval<sink>()(std::declval<source>()(std::declval<P>()...)), void_flag())
 {
 	return payload_not_void;
 }
@@ -40,7 +39,7 @@ template<class source_t, class sink_t>
 struct invoke_helper<payload_void, source_t, sink_t>
 {
 	template<class... param>
-	decltype(auto) operator()(source_t& source, sink_t& sink, param&&... p)
+	constexpr decltype(auto) operator()(source_t& source, sink_t& sink, param&&... p) const
 	{
 		source(std::forward<param>(p)...);
 		return sink();
@@ -51,7 +50,7 @@ template<class source_t, class sink_t>
 struct invoke_helper<payload_not_void, source_t, sink_t>
 {
 	template<class... param>
-	decltype(auto) operator()(source_t& source, sink_t& sink, param&&... p)
+	constexpr decltype(auto) operator()(source_t& source, sink_t& sink, param&&... p) const
 	{
 		return sink(source(std::forward<param>(p)...));
 	}
@@ -92,10 +91,7 @@ constexpr bool void_check_signatures()
 
  * \pre the return value of source_t needs to be convertible to the parameter of sink_t.
  */
-template<
-		class source_t,
-		class sink_t
-		>
+template<class source_t, class sink_t>
 struct connection
 {
 	source_t source;
@@ -111,17 +107,34 @@ struct connection
 	 * and thus be a substitution failure.
 	 */
 	template<class S = source_t, class T = sink_t, class... param>
-	auto operator()(param&&... p)
+	constexpr auto operator()(param&&... p)
 	-> decltype(detail::invoke_helper<
-				detail::void_check<S, T, param...>(0),
-				S,T
-			>()
+					detail::void_check<S, T, param...>(),
+					S,T
+				>()
 			(source, sink, std::forward<param>(p)...))
 	{
-		constexpr auto test = detail::void_check<S, T, param...>(0);
+		constexpr auto test = detail::void_check<S, T, param...>();
 		return detail::invoke_helper<
 					test,
 					S,T
+				>()
+				(source, sink, std::forward<param>(p)...);
+	}
+
+	///const overload of call operator
+	template<class S = source_t, class T = sink_t, class... param>
+	constexpr auto operator()(param&&... p) const
+	-> decltype(detail::invoke_helper<
+				detail::void_check<const S, const T, param...>(),
+				const S, const T
+			>()
+			(source, sink, std::forward<param>(p)...))
+	{
+		constexpr auto test = detail::void_check<const S, const T, param...>();
+		return detail::invoke_helper<
+					test,
+					const S, const T
 				>()
 				(source, sink, std::forward<param>(p)...);
 	}
@@ -134,7 +147,7 @@ namespace detail
 template<class source_t, class sink_t, class Enable = void>
 struct connect_impl
 {
-	auto operator()(source_t&& source, sink_t&& sink)
+	constexpr auto operator()(source_t&& source, sink_t&& sink)
 	{
 		return connection<source_t, sink_t>
 				{std::forward<source_t>(source), std::forward<sink_t>(sink)};
@@ -154,16 +167,15 @@ using rm_ref_t = std::remove_reference_t<T>;
  * \returns connection object which has its type determined by the source_t and sink_t.
  *
  * If source_t and sink_t fulfill connectable, the result is connectable.
- * If one of source_t and sink_t fulfills receive_connectable and the other
- * fulfills send_connectable, the result is not non_connectable.
- * If either source_t or sink_t fulfill send_connectable, the result is send_connectable.
- * If either source_t or sink_t fulfill receive_connectable, the result is receive_connectable.
+ * If one of source_t and sink_t fulfills passive_connectable and the other
+ * fulfills active_connectable, the result is a complete connection and non_connectable.
+ * If either source_t or sink_t fulfill active_connectable, the result is an active connection proxy.
+ * If either source_t or sink_t fulfill passive_connectable, the result is passive_connectable.
  */
-template
-	<	class source_t,
-		class sink_t
-	>
-auto connect (source_t&& source, sink_t&& sink)
+template<class source_t, class sink_t, class enable = std::enable_if_t<
+		(is_connectable_v<source_t> || is_active_source_v<rm_ref_t<source_t>>)
+		&& (is_connectable_v<sink_t> || is_active_sink_v<rm_ref_t<sink_t>>)>>
+constexpr auto connect (source_t&& source, sink_t&& sink)
 {
 	return detail::connect_impl<source_t, sink_t>()(
 	        std::forward<source_t>(source), std::forward<sink_t>(sink));
@@ -172,12 +184,12 @@ auto connect (source_t&& source, sink_t&& sink)
 /**
  * \brief Operator >> takes two connectables and returns a connection.
  *
- * This operator is syntactic sugar for Connect.
+ * This operator is syntactic sugar for connect.
  */
 template<class source_t, class sink_t, class enable = std::enable_if_t<
 		(is_connectable_v<source_t> || is_active_source_v<rm_ref_t<source_t>>)
 		&& (is_connectable_v<sink_t> || is_active_sink_v<rm_ref_t<sink_t>>)>>
-auto operator >>(source_t&& source, sink_t&& sink)
+constexpr auto operator >>(source_t&& source, sink_t&& sink)
 {
 	static_assert(!(is_active_v<rm_ref_t<source_t>> && is_active_v<rm_ref_t<sink_t>>),
 	              "event_source can not be connected to state_sink.");

--- a/flexcore/core/connection_util.hpp
+++ b/flexcore/core/connection_util.hpp
@@ -1,8 +1,9 @@
 #ifndef SRC_PORTS_CONNECTION_UTIL_HPP_
 #define SRC_PORTS_CONNECTION_UTIL_HPP_
 
-#include <utility>
 #include <flexcore/core/traits.hpp>
+
+#include <utility>
 
 namespace fc
 {
@@ -12,7 +13,7 @@ namespace fc
  * Stopping criterion for recursion
  */
 template <class T>
-auto get_source(T& s)
+constexpr auto get_source(T& s)
 	-> std::enable_if_t<!has_source<T>(0), decltype(s)>
 {
 	return s;
@@ -21,7 +22,7 @@ auto get_source(T& s)
  * \brief recursively extracts the source of a connection
  */
 template <class T>
-auto get_source(T& c)
+constexpr auto get_source(T& c)
 	-> std::enable_if_t<has_source<T>(0),
 			decltype(get_source(c.source))>
 {
@@ -33,7 +34,7 @@ auto get_source(T& c)
  * Stopping criterion for recursion
  */
 template <class T>
-auto get_sink(T& s)
+constexpr auto get_sink(T& s)
 	-> std::enable_if_t<!has_sink<T>(0), decltype(s)>
 {
 	return s;
@@ -43,54 +44,12 @@ auto get_sink(T& s)
  * \brief recursively extracts the sink of an object with member "sink"
  */
 template <class T>
-auto get_sink(T& c)
+constexpr auto get_sink(T& c)
 	-> std::enable_if_t<has_sink<T>(0),
 			decltype(get_sink(c.sink))>
 {
 	return get_sink(c.sink);
 }
-
-/**
- * \brief gets the source type of the connectalbe
- * \pre connectable is either a connection or a source
- */
-template <class T, class Enable = void>
-struct get_source_t
-{
-	typedef T type;
-};
-
-/**
- * \brief specialization for the case of a connection
- */
-template <class T>
-struct get_source_t<T,
-		std::enable_if_t< has_source<T>(0) >
-	>
-{
-	typedef typename get_source_t<decltype(std::declval<T>().source)>::type type;
-};
-
-/**
- * \brief gets the sink type of the connectalbe
- * \pre connectable is either a connection or a sink
- */
-template <class T, class Enable = void>
-struct get_sink_t
-{
-	typedef T type;
-};
-
-/**
- * \brief specialization for the case of a connection
- */
-template <class T>
-struct get_sink_t<T,
-		std::enable_if_t< has_sink<T>(0) >
-	>
-{
-	typedef typename get_sink_t<decltype(std::declval<T>().sink)>::type type;
-};
 
 }// namespace fc
 #endif /* SRC_PORTS_CONNECTION_UTIL_HPP_ */

--- a/flexcore/core/tuple_meta.hpp
+++ b/flexcore/core/tuple_meta.hpp
@@ -31,7 +31,7 @@ constexpr auto make_index_sequence()
 
 template<class lhs_tuple, class rhs_tuple, std::size_t ... index,
 class operation>
-decltype(auto) binary_invoke_helper(lhs_tuple&& lsh,
+constexpr decltype(auto) binary_invoke_helper(lhs_tuple&& lsh,
 		rhs_tuple&& rhs,
 		std::index_sequence<index...>,
 		operation&& op)
@@ -44,7 +44,7 @@ decltype(auto) binary_invoke_helper(lhs_tuple&& lsh,
 template<class lhs_tuple, std::size_t ... index,
 class operation>
 
-decltype(auto) unary_invoke_helper(lhs_tuple&& lsh,
+constexpr decltype(auto) unary_invoke_helper(lhs_tuple&& lsh,
 		std::index_sequence<index...>,
 		operation&& op)
 {
@@ -52,7 +52,7 @@ decltype(auto) unary_invoke_helper(lhs_tuple&& lsh,
 }
 
 template<class operation, class tuple, std::size_t... index>
-decltype(auto) invoke_function_helper(
+constexpr decltype(auto) invoke_function_helper(
 		operation&& op, tuple&& tup, std::index_sequence<index...>)
 {
 	return op(std::get<index>(std::forward<tuple>(tup))...);
@@ -61,21 +61,21 @@ decltype(auto) invoke_function_helper(
 
 ///applies function to every element in tuple
 template<class tuple, class operation>
-void for_each(tuple&& tup, operation&& op)
+constexpr void for_each(tuple&& tup, operation&& op)
 {
 	unary_invoke_helper(std::forward<tuple>(tup), detail::make_index_sequence<tuple>(), op);
 }
 
 ///transform, returns tuple of transformed elements
 template<class tuple, class operation>
-decltype(auto) transform(tuple&& tup, const operation& op)
+constexpr decltype(auto) transform(tuple&& tup, const operation& op)
 {
 	return detail::unary_invoke_helper(std::forward<tuple>(tup),
 	                                   detail::make_index_sequence<tuple>(), op);
 }
 ///binary_transform, returns tuple of results of bin_op on elements of first and second tuple
 template<class first_tuple, class second_tuple, class operation>
-decltype(auto) transform(first_tuple&& first, second_tuple&& second, const operation& op)
+constexpr decltype(auto) transform(first_tuple&& first, second_tuple&& second, const operation& op)
 {
 	static_assert(std::tuple_size<std::decay_t<first_tuple>>::value ==
 	                  std::tuple_size<std::decay_t<second_tuple>>::value,
@@ -88,7 +88,7 @@ decltype(auto) transform(first_tuple&& first, second_tuple&& second, const opera
 
 ///Helper function to call variadic functions with tuple
 template<class operation, class tuple>
-decltype(auto) invoke_function(operation&& op, tuple&& tup)
+constexpr decltype(auto) invoke_function(operation&& op, tuple&& tup)
 {
 	return detail::invoke_function_helper(
 			std::forward<operation>(op),

--- a/tests/core/test_connectables.cpp
+++ b/tests/core/test_connectables.cpp
@@ -25,7 +25,8 @@ BOOST_AUTO_TEST_CASE(test_arithmetic_and_logical)
 	BOOST_CHECK_EQUAL(([](){ return 4;} >> divide(2))(), 2);
 
 	BOOST_CHECK_EQUAL(([](){ return -1;} >> absolute{})(), 1);
-	BOOST_CHECK_EQUAL(([](){ return -1.f;} >> absolute{})(), 1.f);
+	BOOST_CHECK_EQUAL(([](){ return  1;} >> absolute{})(), 1);
+	BOOST_CHECK_EQUAL(([](){ return -1.5f;} >> absolute{})(), 1.5f);
 	BOOST_CHECK_EQUAL(([](){ return -1.l;} >> absolute{})(), 1.l);
 
 	BOOST_CHECK_EQUAL(([](){ return 1;} >> negate{})(), -1);
@@ -59,9 +60,8 @@ BOOST_AUTO_TEST_CASE(tee_move_only)
 	int tee_target{0};
 	auto sink = [&target](auto&& in){ target = std::move(in); };
 
-	auto test_con =
-			src >>
-			tee([&tee_target](const auto& ptr) { tee_target = *ptr; })
+	auto test_con =	src
+			>> tee([&tee_target](const auto& ptr) { tee_target = *ptr; })
 			>> sink;
 
 	test_con();
@@ -77,6 +77,14 @@ BOOST_AUTO_TEST_CASE(test_print)
 	connection();
 
 	BOOST_CHECK_EQUAL(test_stream.str(), "1\n");
+}
+
+BOOST_AUTO_TEST_CASE(test_constexpr_connectables)
+{
+	constexpr auto con = increment{} >> decrement{} >> identity{};
+	constexpr auto val = con(0);
+	static_assert(val == 0, "");
+	static_assert(con(1) == 1, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/core/test_connection.cpp
+++ b/tests/core/test_connection.cpp
@@ -240,4 +240,22 @@ BOOST_AUTO_TEST_CASE( apply_to_connection )
 	BOOST_CHECK(c_visited);
 }
 
+struct constexpr_add
+{
+	template<class T>
+	constexpr auto operator()(T x) const
+	{
+		return ++x;
+	}
+};
+
+BOOST_AUTO_TEST_CASE( constexpr_connection )
+{
+	using fc::operator>>;
+	constexpr auto con = constexpr_add{} >> constexpr_add{};
+	constexpr auto test_val = con(1);
+	static_assert(test_val == 3, "compile time eval");
+
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Connections and basic connectables are now constexpr.
This makes it possible to evaluate simple connections at compile time.

While this is probably more cool than actually useful the test serve as regression tests
against accidentally adding runtime complexities like allocations to core facilities.